### PR TITLE
Custom observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 
-[![Build status](https://toolfactory.visualstudio.com/Core/_apis/build/status/Mectrics%20Libraries/Bluekiri.Diagnostics.Prometheus-CI?branchName=development)](https://toolfactory.visualstudio.com/Core/_build/latest?definitionId=773)
-
 [![Build status](https://toolfactory.visualstudio.com/Core/_apis/build/status/Mectrics%20Libraries/Bluekiri.Diagnostics.Prometheus-CI?branchName=master)](https://toolfactory.visualstudio.com/Core/_build/latest?definitionId=773)
 
 # bluekiri-diagnostics-prometheus
 This library is meant to expose DiagnosticSource events as Prometheus metrics using [prometheus-net](https://github.com/prometheus-net/prometheus-net).
-Currently, we exponse events from the following sources
+Currently, we expose events from the following sources:
 
  - HttpHandlerDiagnosticListener. This source logs the events of outgoing HTTP connections made with HttpClient.
  - Microsoft.AspNetCore. This source logs events coming from de ASP.NET Core pipeline.
@@ -35,12 +33,32 @@ Currently, we exponse events from the following sources
     ```
  3. Prometheus metrics will be exposed in the /metrics endpoint in the port 9303 of your host, since in this sample we configured a KestrelMetricServer in this port.
 
+### Adding a custom observer for a listener
+You can add a custom observer for a specific listener. First, you need to make an implementation of IObserver<string, object>. Finally, you can subscribe this observer to diagnostic listeners in the following way:
+```csharp
+public static void Main(string[] args)
+{
+    // Creating the kestrel metrics server listening
+    // into another port
+    var metricsServer = new KestrelMetricServer(9303);
+    metricsServer.Start();
+
+    // Subscribe YourObserver for the specified Diagnostic Listener.
+    // This method also adds the default observers added with SubscribeDiagnosticListener() extension method
+    DiagnosticListener.AllListeners.SubscribeDiagnosticListener(o => {
+        o.AddSubscriber("TheDiagnosticListenerNameYouWantToSubscribeTo", new YourObserver());
+    });
+
+    CreateWebHostBuilder(args).Build().Run();
+}
+```
+
 ## References
 - [DiagnosticSource User Guide](https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/DiagnosticSourceUsersGuide.md)
 - [HttpDiagnostics Guide](https://github.com/dotnet/corefx/blob/master/src/System.Net.Http/src/HttpDiagnosticsGuide.md)
 
 ## Contributing
-Your help is always welcome. You can contribute to this project opening issues reporting bugs or new feature requests, or by sending pull requests to our development branch for new features, or to our master branch for bug fixes.
+Your help is always welcome. You can contribute to this project opening issues reporting bugs or new feature requests, or by sending pull requests with new features or bug fixes.
 
 ## License
 This project is licensed under [MIT License](LICENSE.md)

--- a/src/Bluekiri.Diagnostics.Prometheus/DiagnosticListenerObservableExtensions.cs
+++ b/src/Bluekiri.Diagnostics.Prometheus/DiagnosticListenerObservableExtensions.cs
@@ -5,19 +5,35 @@ namespace Bluekiri.Diagnostics.Prometheus
 {
     public static class DiagnosticListenerObservableExtensions
     {
-
+        /// <summary>
+        /// Subscribes the default observers for HttHandlerDiagnosticListener and Microsoft.AspNetCore
+        /// </summary>
+        /// <param name="observable"></param>
         public static void SubscribeDiagnosticListener(this IObservable<DiagnosticListener> observable)
         {
+            observable.SubscribeDiagnosticListener(null);
+        }
+
+        /// <summary>
+        /// Subscribes a custom set of observers to specific Diagnostic Listeners
+        /// </summary>
+        /// <param name="observable"></param>
+        /// <param name="configure">The action that adds the custom observers</param>
+        public static void SubscribeDiagnosticListener(this IObservable<DiagnosticListener> observable, Action<SubscribeOptions> configure)
+        {
+            var options = new SubscribeOptions();
+            options.AddDefaultObservers();
+
+            if(!(configure is null))
+            {
+                configure(options);
+            }            
+
             observable.Subscribe(delegate (DiagnosticListener listener)
             {
-                if (listener.Name == "HttpHandlerDiagnosticListener")
+                if (options.Observers.ContainsKey(listener.Name))
                 {
-                    listener.Subscribe(new HttpHandlerDiagnosticListenerObserver());
-                }
-
-                if (listener.Name == "Microsoft.AspNetCore")
-                {
-                    listener.Subscribe(new AspNetCoreDiagnosticListenerObserver());
+                    listener.Subscribe(options.Observers[listener.Name]);
                 }
             });
         }

--- a/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptions.cs
+++ b/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptions.cs
@@ -7,6 +7,11 @@ namespace Bluekiri.Diagnostics.Prometheus
     {         
         internal IDictionary<string, IObserver<KeyValuePair<string, object>>> Observers { get; set; }
 
+        public SubscribeOptions()
+        {
+            Observers = new Dictionary<string, IObserver<KeyValuePair<string, object>>>();
+        }
+
         public void AddSubscriber(string listenerName, IObserver<KeyValuePair<string, object>> listenerObserver)
         {
             Observers.Add(listenerName, listenerObserver);

--- a/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptions.cs
+++ b/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Bluekiri.Diagnostics.Prometheus
+{
+    public class SubscribeOptions
+    {         
+        internal IDictionary<string, IObserver<KeyValuePair<string, object>>> Observers { get; set; }
+
+        public void AddSubscriber(string listenerName, IObserver<KeyValuePair<string, object>> listenerObserver)
+        {
+            Observers.Add(listenerName, listenerObserver);
+        }
+
+        public void Clear()
+        {
+            Observers.Clear();
+        }
+    }
+}

--- a/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptionsExtensions.cs
+++ b/src/Bluekiri.Diagnostics.Prometheus/SubscribeOptionsExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace Bluekiri.Diagnostics.Prometheus
+{
+    public static class SubscribeOptionsExtensions
+    {
+        /// <summary>
+        /// Adds the default observers
+        /// </summary>
+        /// <param name="o"></param>
+        public static void AddDefaultObservers(this SubscribeOptions o)
+        {
+            o.AddSubscriber("HttpHandlerDiagnosticListener", new HttpHandlerDiagnosticListenerObserver());
+            o.AddSubscriber("Microsoft.AspNetCore", new AspNetCoreDiagnosticListenerObserver());
+        }
+    }
+}

--- a/test/Bluekiri.Diagnostics.Prometheus.Tests/DiagnosticListenerObservableExtensionsTest.cs
+++ b/test/Bluekiri.Diagnostics.Prometheus.Tests/DiagnosticListenerObservableExtensionsTest.cs
@@ -1,0 +1,147 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Bluekiri.Diagnostics.Prometheus.Tests
+{
+    [TestClass]
+    public class DiagnosticListenerObservableExtensionsTest
+    {
+        class FakeDiagnosticListenerObservable : IObservable<DiagnosticListener>
+        {
+            private readonly List<IObserver<DiagnosticListener>> _observers;
+            private readonly List<DiagnosticListener> _listeners;
+
+            public FakeDiagnosticListenerObservable()
+            {
+                _observers = new List<IObserver<DiagnosticListener>>();
+                _listeners = new List<DiagnosticListener>();
+            }
+
+            private class Unsubscriber : IDisposable
+            {
+                private List<IObserver<DiagnosticListener>> _observers;
+                private IObserver<DiagnosticListener> _observer;
+
+                public Unsubscriber(List<IObserver<DiagnosticListener>> observers, IObserver<DiagnosticListener> observer)
+                {
+                    _observers = observers;
+                    _observer = observer;
+                }
+                public void Dispose()
+                {
+                    if (!(_observer is null)) _observers.Remove(_observer);
+                }
+            }
+
+            public IDisposable Subscribe(IObserver<DiagnosticListener> observer)
+            {
+                if (!_observers.Contains(observer))
+                    _observers.Add(observer);
+
+                return new Unsubscriber(_observers, observer);
+            }
+
+            public void AddListener(DiagnosticListener listener)
+            {
+                _listeners.Add(listener);
+            }
+
+            public void CommitData()
+            {
+                foreach (var listener in _listeners)
+                {
+                    foreach (var observer in _observers)
+                    {
+                        observer.OnNext(listener);
+                    }
+                }
+            }
+        }
+
+        class TestObserverForTestDiagnosticListener : IObserver<KeyValuePair<string, object>>
+        {
+            public void OnCompleted()
+            {                
+            }
+
+            public void OnError(Exception error)
+            {                
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {                
+            }
+        }
+
+        [TestMethod]
+        public void SubscribeDiagnosticListener_DefaultListenersSubscribed()
+        {
+            // Arrange
+            var diagnosticListenerObservable = new FakeDiagnosticListenerObservable();
+            var httpClientDiagnosticListener = new DiagnosticListener("HttpHandlerDiagnosticListener");
+            var aspNetCoreDiagnosticListener = new DiagnosticListener("Microsoft.AspNetCore");
+
+            diagnosticListenerObservable.AddListener(httpClientDiagnosticListener);
+            diagnosticListenerObservable.AddListener(aspNetCoreDiagnosticListener);
+            diagnosticListenerObservable.SubscribeDiagnosticListener();
+
+            // Act
+
+            // This notifies the diagnostic listeners observers about the different diagnostic listeners registered.
+            // We register one observer using SubscribeDiagnosticListener. 
+            // At the same time, when notified, this observer registers the adequate
+            // observers into each one of the Diagnostic Listeners.
+            diagnosticListenerObservable.CommitData();
+
+            // Assert     
+            var subscriptionsField = typeof(DiagnosticListener).GetField("_subscriptions",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var httpClientDiagnosticListenerSubscriptions = subscriptionsField.GetValue(httpClientDiagnosticListener);
+
+            var httpClientDiagnosticListenerObserver = httpClientDiagnosticListenerSubscriptions.GetType()
+                .GetField("Observer",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetValue(httpClientDiagnosticListenerSubscriptions);
+
+            var aspNetCoreDiagnosticListenerSubscriptions = subscriptionsField.GetValue(aspNetCoreDiagnosticListener);
+            var aspNetCoreDiagnosticListenerObserver = aspNetCoreDiagnosticListenerSubscriptions.GetType()
+                .GetField("Observer",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetValue(aspNetCoreDiagnosticListenerSubscriptions);
+
+            Assert.IsInstanceOfType(httpClientDiagnosticListenerObserver, typeof(HttpHandlerDiagnosticListenerObserver));
+            Assert.IsInstanceOfType(aspNetCoreDiagnosticListenerObserver, typeof(AspNetCoreDiagnosticListenerObserver));
+        }
+
+        [TestMethod]
+        public void SubscribeDiagnosticListener_CustomDiagnosticListenerObserverSubscribed()
+        {
+            // Arrange
+            var diagnosticListenerObservable = new FakeDiagnosticListenerObservable();
+            var testDiagnosticListener = new DiagnosticListener("TestDiagnosticListener");
+
+            diagnosticListenerObservable.AddListener(testDiagnosticListener);
+            diagnosticListenerObservable.SubscribeDiagnosticListener(o =>
+            {
+                o.AddSubscriber("TestDiagnosticListener", new TestObserverForTestDiagnosticListener());
+            });
+
+            // Act
+            diagnosticListenerObservable.CommitData();
+
+            // Assert
+            var subscriptionsField = typeof(DiagnosticListener).GetField("_subscriptions",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var testDiagnosticListenerSubscriptions = subscriptionsField.GetValue(testDiagnosticListener);
+
+            var testDiagnosticListenerObserver = testDiagnosticListenerSubscriptions.GetType()
+                .GetField("Observer",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .GetValue(testDiagnosticListenerSubscriptions);
+
+            Assert.IsInstanceOfType(testDiagnosticListenerObserver, typeof(TestObserverForTestDiagnosticListener));
+        }
+    }
+}


### PR DESCRIPTION
The possibility of adding custom observers for other diagnostic sources has been added. Also the documentation has been updated accordingly and the unit tests have been created.