### PR TITLE
Remove VersionPrefix

### DIFF
--- a/src/Bluekiri.Diagnostics.Prometheus/Bluekiri.Diagnostics.Prometheus.csproj
+++ b/src/Bluekiri.Diagnostics.Prometheus/Bluekiri.Diagnostics.Prometheus.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Bluekiri.Diagnostics.Prometheus</AssemblyName>
-    <PackageId>Bluekiri.Diagnostics.Prometheus</PackageId>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <PackageId>Bluekiri.Diagnostics.Prometheus</PackageId>    
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>


### PR DESCRIPTION
The version prefix will be removed since the version numbers will be generated by combining tagging + GitVersion